### PR TITLE
This should fix the reported "memory leaks" 

### DIFF
--- a/src/main/java/net/commoble/hyperbox/HyperboxDebug.java
+++ b/src/main/java/net/commoble/hyperbox/HyperboxDebug.java
@@ -1,0 +1,93 @@
+package net.commoble.hyperbox;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HyperboxDebug {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HyperboxDebug.class);
+
+    private static final Map<ResourceLocation, Long> activeDimensions = new ConcurrentHashMap<>();
+
+    private static final Map<ResourceLocation, Map<Long, Long>> forcedChunks = new ConcurrentHashMap<>();
+
+    public static void logDimensionCreated(@NotNull ResourceKey<Level> dimensionKey) {
+        ResourceLocation location = dimensionKey.location();
+        activeDimensions.put(location, System.currentTimeMillis());
+        LOGGER.info("Hyperbox dimension created: {}", location);
+    }
+
+    public static void logDimensionUnloaded(@NotNull ResourceKey<Level> dimensionKey) {
+        ResourceLocation location = dimensionKey.location();
+        Long created = activeDimensions.remove(location);
+        long duration = created != null ? System.currentTimeMillis() - created : -1;
+        LOGGER.info("Hyperbox dimension unloaded: {}, was active for {} ms", location, duration);
+
+        forcedChunks.remove(location);
+    }
+
+    public static void logChunkForced(@NotNull ResourceKey<Level> dimensionKey, int x, int z) {
+        ResourceLocation location = dimensionKey.location();
+        forcedChunks.computeIfAbsent(location, k -> new HashMap<>())
+                .put(ChunkPos.asLong(x, z), System.currentTimeMillis());
+        LOGGER.debug("Chunk forced in {}: ({}, {})", location, x, z);
+    }
+
+    public static void logChunkUnforced(@NotNull ResourceKey<Level> dimensionKey, int x, int z) {
+        ResourceLocation location = dimensionKey.location();
+        Map<Long, Long> chunks = forcedChunks.get(location);
+        if (chunks != null) {
+            Long forced = chunks.remove(ChunkPos.asLong(x, z));
+            long duration = forced != null ? System.currentTimeMillis() - forced : -1;
+            LOGGER.debug("Chunk unforced in {}: ({}, {}), was forced for {} ms", location, x, z, duration);
+        }
+    }
+
+    public static void dumpDebugInfo(MinecraftServer server) {
+        LOGGER.info("=== HYPERBOX DEBUG INFO ===");
+        LOGGER.info("Active dimensions: {}", activeDimensions.size());
+
+        for (ResourceLocation dimId : activeDimensions.keySet()) {
+            ServerLevel level = server.getLevel(ResourceKey.create(Registries.DIMENSION, dimId));
+            int forcedChunkCount = level != null ? level.getForcedChunks().size() : -1;
+
+            LOGGER.info("  Dimension: {}", dimId);
+            LOGGER.info("    Created: {} ms ago", System.currentTimeMillis() - activeDimensions.get(dimId));
+            LOGGER.info("    Forced chunks: {}", forcedChunkCount);
+
+            Map<Long, Long> chunks = forcedChunks.get(dimId);
+            if (chunks != null && !chunks.isEmpty()) {
+                LOGGER.info("    Tracked forced chunks: {}", chunks.size());
+                chunks.forEach((pos, time) -> {
+                    ChunkPos chunkPos = new ChunkPos(pos);
+                    LOGGER.info("      Chunk ({}, {}): forced {} ms ago",
+                            chunkPos.x, chunkPos.z, System.currentTimeMillis() - time);
+                });
+            }
+        }
+
+        LOGGER.info("===========================");
+    }
+
+    public static void schedulePeriodicDumps(@NotNull MinecraftServer server) {
+        server.getCommands().getDispatcher().register(
+                net.minecraft.commands.Commands.literal("hyperboxdebug")
+                        .requires(source -> source.hasPermission(2))
+                        .executes(context -> {
+                            dumpDebugInfo(context.getSource().getServer());
+                            return 1;
+                        })
+        );
+    }
+}


### PR DESCRIPTION
Even though during my testing there fucking is **_### none_**.

Dumps provided  
![DeleteAllComparedTo20Made](https://github.com/user-attachments/assets/c33d8ed5-0c79-4f2e-9053-f4928b4630f0)
![GC-Heap-Compared-To-20-Hyperboxes-Made](https://github.com/user-attachments/assets/f786667e-2f56-46d0-965a-bb18960774dd)

Compared with _**8**_ separate dumps, absolutely no retained memory when comparing my baseline heap to creating and breaking 10-20 hyperboxes**

- Added proper cleanup in `onRemove()` method
- Implemented event handlers for server shutdown
- Fixed possible issue where chunks may have remained force-loaded after block removal
- Added For loops to iterate over every possible chunkPos
- Retaining blocks in hashset that can then be handled moreso
- Added Debugger to aid in reporting of freeing resources